### PR TITLE
Handle multiple indices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 psql-schema-dump-sanitiser
 
 # dev test files
+dump.sql
 schema.sql
 output.sql
 

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -101,6 +101,10 @@ func IsRedundant(line string) bool {
 	if strings.Contains(line, "EXTENSION") || strings.Contains(line, "OWNER") {
 		return true
 	}
+	// Skip config select statements
+	if strings.Contains(line, "SELECT pg_catalog.set_config") {
+		return true
+	}
 
 	return false
 }

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -362,7 +362,7 @@ func MapIndices(lines []string, tables map[string]*Table) ([]string, error) {
 				}
 			}
 			if table, ok := tables[tableName]; ok {
-				table.Index = line
+				table.Index = append(table.Index, line)
 			} else {
 				return lines, fmt.Errorf("mapping indices - table does not exist")
 			}
@@ -481,6 +481,7 @@ func getReferenceTables(tableName string, tables map[string]*Table) []string {
 		if strings.Contains(constraint, "FOREIGN KEY") {
 			tokens := strings.Split(constraint, "REFERENCES ")
 			ref := removeAccessModifier(tokens[1][:strings.Index(tokens[1], "(")])
+			refTables = append(refTables, ref)
 		}
 	}
 	return refTables
@@ -555,7 +556,9 @@ func PrintSchema(tables map[string]*Table) {
 			printTable(tableName, table)
 		}
 		if len(table.Index) > 0 {
-			fmt.Println(table.Index)
+			for _, index := range table.Index {
+				fmt.Println(index)
+			}
 		}
 		if i < len(tableNames)-1 {
 			fmt.Println()

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -232,7 +232,7 @@ func MapSequences(lines []string, tables map[string]*Table) ([]string, error) {
 				if table, ok := tables[tableName]; ok {
 					table.Sequences = append(table.Sequences, sequence)
 				} else {
-					return lines, fmt.Errorf("table does not exist")
+					return lines, fmt.Errorf("mapping sequences - table does not exist")
 				}
 			}
 		} else if strings.Contains(line, "ALTER SEQUENCE") && strings.Contains(line, "OWNED BY") {
@@ -277,10 +277,10 @@ func MapDefaultValues(lines []string, tables map[string]*Table) ([]string, error
 					column.Statement += " " + line[index:len(line)-1]
 					table.Columns = columns
 				} else {
-					return lines, fmt.Errorf("column does not exist")
+					return lines, fmt.Errorf("mapping default values - column does not exist")
 				}
 			} else {
-				return lines, fmt.Errorf("table does not exist")
+				return lines, fmt.Errorf("mapping default values - table does not exist")
 			}
 		} else {
 			bufferLines = append(bufferLines, line)
@@ -309,7 +309,7 @@ func MapConstraints(lines []string, tables map[string]*Table) ([]string, error) 
 			if table, ok := tables[tableName]; ok {
 				table.Constraints[constraintName] = line[index : len(line)-1]
 			} else {
-				return lines, fmt.Errorf("table does not exist")
+				return lines, fmt.Errorf("mapping constraints - table does not exist")
 			}
 
 			// update column primary or foreign keys
@@ -320,7 +320,7 @@ func MapConstraints(lines []string, tables map[string]*Table) ([]string, error) 
 						currentCol.IsPrimaryKey = true
 					} else {
 						delete(tables[tableName].Constraints, constraintName)
-						return lines, fmt.Errorf("column does not exist")
+						return lines, fmt.Errorf("mapping constraints - column does not exist")
 					}
 				}
 			} else if strings.Index(line, "FOREIGN KEY") != -1 {
@@ -364,7 +364,7 @@ func MapIndices(lines []string, tables map[string]*Table) ([]string, error) {
 			if table, ok := tables[tableName]; ok {
 				table.Index = line
 			} else {
-				return lines, fmt.Errorf("table does not exist")
+				return lines, fmt.Errorf("mapping indices - table does not exist")
 			}
 		} else {
 			bufferLines = append(bufferLines, line)

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -179,7 +179,7 @@ func TestMapSequences(t *testing.T) {
 			inputTables:    map[string]*Table{"table2": &Table{}},
 			expectedTables: map[string]*Table{"table2": &Table{}},
 			expectedLines:  []string{"CREATE SEQUENCE seq START WITH 1 INCREMENT BY 1 NO MINVALUE NO MAXVALUE CACHE 1;", "ALTER SEQUENCE seq OWNED BY table1.col;"},
-			expectedError:  fmt.Errorf("table does not exist"),
+			expectedError:  fmt.Errorf("mapping sequences - table does not exist"),
 		},
 		{
 			name:           "Sequence statements with default flags",
@@ -300,7 +300,7 @@ func TestMapDefaultValues(t *testing.T) {
 			inputTables:    map[string]*Table{"table2": &Table{}},
 			expectedTables: map[string]*Table{"table2": &Table{}},
 			expectedLines:  []string{"ALTER TABLE ONLY test ALTER COLUMN id SET DEFAULT nextval('seq'::regclass);"},
-			expectedError:  fmt.Errorf("table does not exist"),
+			expectedError:  fmt.Errorf("mapping default values - table does not exist"),
 		},
 		{
 			name:           "Column does not exist",
@@ -308,7 +308,7 @@ func TestMapDefaultValues(t *testing.T) {
 			inputTables:    map[string]*Table{"table1": &Table{Columns: make(map[string]*Column)}},
 			expectedTables: map[string]*Table{"table1": &Table{Columns: make(map[string]*Column)}},
 			expectedLines:  []string{"ALTER TABLE ONLY table1 ALTER COLUMN id SET DEFAULT nextval('seq'::regclass);"},
-			expectedError:  fmt.Errorf("column does not exist"),
+			expectedError:  fmt.Errorf("mapping default values - column does not exist"),
 		},
 		{
 			name:           "Default seq value",
@@ -436,7 +436,7 @@ func TestMapConstraints(t *testing.T) {
 			inputTables:    map[string]*Table{"table2": &Table{}},
 			expectedTables: map[string]*Table{"table2": &Table{}},
 			expectedLines:  []string{"ALTER TABLE ONLY table1 ADD CONSTRAINT table_pkey PRIMARY KEY (id);"},
-			expectedError:  fmt.Errorf("table does not exist"),
+			expectedError:  fmt.Errorf("mapping constraints - table does not exist"),
 		},
 		{
 			name:           "Column does not exist - primary key",
@@ -444,7 +444,7 @@ func TestMapConstraints(t *testing.T) {
 			inputTables:    map[string]*Table{"table1": &Table{Constraints: make(map[string]string)}},
 			expectedTables: map[string]*Table{"table1": &Table{Constraints: make(map[string]string)}},
 			expectedLines:  []string{"ALTER TABLE ONLY table1 ADD CONSTRAINT table_pkey PRIMARY KEY (id);"},
-			expectedError:  fmt.Errorf("column does not exist"),
+			expectedError:  fmt.Errorf("mapping constraints - column does not exist"),
 		},
 		{
 			name:           "Column does not exist - foreign key",
@@ -533,7 +533,7 @@ func TestMapIndices(t *testing.T) {
 			inputTables:    map[string]*Table{"table2": &Table{}},
 			expectedTables: map[string]*Table{"table2": &Table{}},
 			expectedLines:  []string{"CREATE UNIQUE INDEX user_idx ON table1 USING btree (username);"},
-			expectedError:  fmt.Errorf("table does not exist"),
+			expectedError:  fmt.Errorf("mapping indices - table does not exist"),
 		},
 		{
 			name:           "Create index",

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -496,8 +496,8 @@ func TestMapConstraints(t *testing.T) {
 func TestMapIndices(t *testing.T) {
 	inputTable1 := &Table{}
 	inputTable2 := &Table{}
-	expectedTable1 := &Table{Index: "CREATE UNIQUE INDEX user_idx ON table1 USING btree (username);"}
-	expectedTable2 := &Table{Index: "CREATE UNIQUE INDEX user_idx ON table2 USING btree (username);"}
+	expectedTable1 := &Table{Index: []string{"CREATE UNIQUE INDEX user_idx ON table1 USING btree (username);"}}
+	expectedTable2 := &Table{Index: []string{"CREATE UNIQUE INDEX user_idx ON table2 USING btree (username);"}}
 	inputTablesMap1 := map[string]*Table{"table1": inputTable1}
 	expectedTablesMap1 := map[string]*Table{"table1": expectedTable1}
 	inputTablesMap2 := map[string]*Table{"table2": inputTable2}


### PR DESCRIPTION
Multiple fixes tied to the same issue. Sanitiser now allows tables to have multiple indices.

Fixes #8 